### PR TITLE
fix: Upload apks as draft

### DIFF
--- a/scripts/deploy-android.sh
+++ b/scripts/deploy-android.sh
@@ -51,6 +51,7 @@ if [ "$TRACK" = "internal" ]; then
     skip_upload_metadata:true \
     skip_upload_images:true \
     skip_upload_screenshots:true \
+    release_status:draft \
     aab:android/app/build/outputs/bundle/release/app-release.aab \
     json_key:fastlane/google-api-key.json \
     package_name:$PACKAGE


### PR DESCRIPTION
I get this error when trying to upload apks to a new app (I have already uploaded a build manually) 

> [!] Google Api Error: Invalid request - Only releases with status draft may be created on draft app.